### PR TITLE
For manual install use PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ERLBINS=Install escript run_erl beam dyn_erl etop runcgi.sh beam.smp edoc_generate format_man_pages snmpc bench.sh emem getop start cdv epmd heart start_webtool child_setup erl inet_gethost to_erl codeline_preprocessing.escript erl.src makewhatis typer ct_run erl_call memsup xml_from_edoc.escript dialyzer erlc odbcserver diameterc erlexec printenv.sh
 
-PREFIX?=$(DESTDIR)/usr/local
+PREFIX?=/usr/local
 BINDIR=$(PREFIX)/bin
 CC=gcc
 CFLAGS=-O2 -Wall

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ make
 sudo make install
  # the default location is /usr/local/bin/erln8
  # OR
-make DESTDIR=/some/path install
+make PREFIX=/some/path install
 ```
 
 ## Dependencies


### PR DESCRIPTION
Existing documentation uses DESTDIR which injects"/usr/local" after the DESTDIR which is probably not the expected behavior
