### PR TITLE
Update source copy with tar to pass `-f -` option

### DIFF
--- a/erln8.c
+++ b/erln8.c
@@ -1006,7 +1006,7 @@ void build_erlang(gchar* repo, gchar* tag, gchar* id, gchar* build_config) {
                                 source_path,
                                 " && git archive ",
                                 tag,
-                                " | (cd ", tmp, "; tar x)", NULL);
+                                " | (cd ", tmp, "; tar -f - -x)", NULL);
   gchar* buildcmd1 = g_strconcat(env, " cd ", tmp,
                                 " && ./otp_build autoconf > ", log_path, " 2>&1", NULL);
   gchar* buildcmd2 = g_strconcat(env, " cd ", tmp,


### PR DESCRIPTION
While trying to build OTP-17.0.2 on PC-BSD, I received this error:

``` bash
cdykes@pcbsd:~$ erln8 --build --tag OTP-17.0.2 --id 17.0.2 CC=gcc46
Repo not specified, using default
defaultUsing default config
Building 17.0.2 from tag/branch OTP-17.0.2 of repo default
Custom build config:
Custom build env:
Build log: /usr/home/cdykes/.erln8.d/logs/build_17.0.2_2014-06-06T03:26:02.266760Z
[0] copy source                    tar: Error opening archive: Failed to
open '/dev/sa0'
[0] copy source
Here are the last 10 lines of the log file:
tail: /usr/home/cdykes/.erln8.d/logs/build_17.0.2_2014-06-06T03:26:02.266760Z: No such file or directory
ERROR: Cannot run tail -10 on /usr/home/cdykes/.erln8.d/logs/build_17.0.2_2014-06-06T03:26:02.266760Z
```

The most interesting part is tar trying to read from the default input source `/dev/sa0`. By updating erln8 to pass the `-f -` option to tar, instructing it to read from STDIN, the error was successfully resolved.

I ran the test suite in Ubuntu precise64 without any failures:

``` bash
vagrant@precise64:~/shell/erln8/test(patch-1)$ make
cd ../ && make
make[1]: Entering directory `/home/vagrant/shell/erln8'
gcc -o erln8 erln8.c `pkg-config --cflags --libs glib-2.0 gio-2.0` -DGLIB_DISABLE_DEPRECATION_WARNINGS -O2 -Wall
make[1]: Leaving directory `/home/vagrant/shell/erln8'
ruby erln8_tests.rb
test/unit warning: method Erln8Test#test_ini is redefined
Run options:

# Running tests:

Finished tests in 2.010377s, 6.4664 tests/s, 15.4200 assertions/s.
13 tests, 31 assertions, 0 failures, 0 errors, 0 skips

ruby -v: ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-linux]
```
